### PR TITLE
List and retrieve attractions; Tests pass for attractions

### DIFF
--- a/kennywood/urls.py
+++ b/kennywood/urls.py
@@ -7,6 +7,7 @@ from kennywoodapi.views import *
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'areas', ParkAreaViewset, 'parkarea')
+router.register(r'attractions', AttractionViewset, 'attraction')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/kennywoodapi/views/__init__.py
+++ b/kennywoodapi/views/__init__.py
@@ -1,2 +1,4 @@
 from .auth import login_user, register_user
-from .parkarea import ParkAreaViewset
+from .parkarea import ParkAreaViewset, ParkAreaSerializer
+from .attraction import AttractionViewset
+from .attractioncategory import AttractionCategorySerializer

--- a/kennywoodapi/views/attraction.py
+++ b/kennywoodapi/views/attraction.py
@@ -1,0 +1,51 @@
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from kennywoodapi.models import Attraction
+from .parkarea import ParkAreaSerializer
+from .attractioncategory import AttractionCategorySerializer
+
+
+class AttractionSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for attractions"""
+
+    area = ParkAreaSerializer(many=False)
+    category = AttractionCategorySerializer(many=False)
+
+    class Meta:
+        model = Attraction
+        url = serializers.HyperlinkedIdentityField(
+            view_name="attraction-detail",
+            lookup_field='id'
+        )
+        fields = ('id', 'name', 'max_occupancy',
+                  'height_requirement_inches', 'area', 'category')
+
+
+class AttractionViewset(ViewSet):
+    """
+    View for interacting with attractions
+    """
+
+    def retrieve(self, request, pk=None):
+        try:
+            attraction = Attraction.objects.get(pk=pk)
+            serializer = AttractionSerializer(
+                attraction, context={'request': request})
+            return Response(serializer.data)
+
+        except Attraction.DoesNotExist as ex:
+            return Response(
+                {'message': "The requested attraction does not exist, or you do not have permission to access it"},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+    def list(self, request):
+        attractions = Attraction.objects.all()
+
+        json_attractions = AttractionSerializer(
+            attractions, many=True, context={'request': request}
+        )
+
+        return Response(json_attractions.data)

--- a/kennywoodapi/views/attractioncategory.py
+++ b/kennywoodapi/views/attractioncategory.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from kennywoodapi.models import AttractionCategory
+
+
+class AttractionCategorySerializer(serializers.ModelSerializer):
+    """JSON serializer for attraction categories"""
+
+    class Meta:
+        model = AttractionCategory
+        url = serializers.HyperlinkedIdentityField(
+            view_name="attractioncategory-detail",
+            lookup_field='id'
+        )
+        fields = ('id', 'name', 'description')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 from .user import UserTests
 from .parkarea import ParkAreaTests
+from .attraction import AttractionTests

--- a/tests/attraction.py
+++ b/tests/attraction.py
@@ -1,0 +1,108 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from kennywoodapi.models import Attraction, AttractionCategory, ParkArea, TargetPopulation
+
+
+class AttractionTests(APITestCase):
+    def setUp(self) -> None:
+        """
+        Initialize a couple of park areas and assign a couple
+        of target population types
+        """
+
+        # Initialize user
+        url = "/register"
+        data = {
+            "username": "test@test.com",
+            "email": "test@test.com",
+            "password": "password",
+            "first_name": "test_firstname",
+            "last_name": "test_lastname",
+            "phone_number": "123-456-7890",
+            "special_requirements": "wheelchair",
+            "number_family_members": 3
+        }
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.token = json_response["token"]
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Create target population records
+        pop_kids = TargetPopulation.objects.create(
+            name="Kids"
+        )
+        pop_kids.save()
+
+        pop_adults = TargetPopulation.objects.create(
+            name="Adults"
+        )
+        pop_adults.save()
+
+        # Create park areas
+        adult_parkarea = ParkArea.objects.create(
+            name="Adult Park Area",
+            target_population=pop_adults
+        )
+        adult_parkarea.save()
+
+        kids_parkarea = ParkArea.objects.create(
+            name="Kids Park Area",
+            target_population=pop_kids
+        )
+        kids_parkarea.save()
+
+        # Create attraction category
+        category = AttractionCategory.objects.create(
+            name="Rides",
+            description="Test Rides Description"
+        )
+
+        # Create attractions
+        first_attraction = Attraction.objects.create(
+            name="First Attraction",
+            area=adult_parkarea,
+            category=category,
+            max_occupancy=123,
+            height_requirement_inches=36
+        )
+
+        seond_attraction = Attraction.objects.create(
+            name="Second Attraction",
+            area=kids_parkarea,
+            category=category,
+            max_occupancy=222,
+            height_requirement_inches=22
+        )
+
+    def test_list_attractions(self):
+        """
+        Get list of attractions
+        """
+
+        url = "/attractions"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 2)
+
+    def test_retrieve_single_attraction(self):
+        """
+        Get a specific attraction
+        """
+
+        url = "/attractions/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+        self.assertEqual(json_response["name"], "First Attraction")
+        self.assertEqual(json_response["max_occupancy"], 123)
+        self.assertEqual(json_response["height_requirement_inches"], 36)
+        self.assertEqual(json_response["category"]["id"], 1)


### PR DESCRIPTION
Adds endpoint to retrieve attractions and adds tests to validate that functionality.

## Changes

- Add `/attractions` endpoint to retrieve and list attractions
- Add `AttractionCategorySerializer` to support including the category details on the attraction
- Add tests to validate `/attractions` endpoint functionality

## Requests / Responses

**Request**

GET `/attractions`  -> Gets a list of all attractions

**Response (excerpt)**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Lights, Camera, Action!: Extreme Stunt Show",
        "max_occupancy": 150,
        "height_requirement_inches": null,
        "area": {
            "id": 5,
            "url": "http://localhost:8000/areas/5",
            "name": "Streets of America",
            "target_population": {
                "id": 3,
                "name": "Adults"
            }
        },
        "category": {
            "id": 3,
            "name": "Themed",
            "description": "Visitors walk through themed structures. Haunted houses, wax museums, etc."
        }
    },
    {
        "id": 2,
        "name": "Adventure Alley Games",
        "max_occupancy": null,
        "height_requirement_inches": null,
        "area": {
            "id": 1,
            "url": "http://localhost:8000/areas/1",
            "name": "Adventure Alley",
            "target_population": {
                "id": 2,
                "name": "Kids"
            }
        },
        "category": {
            "id": 2,
            "name": "Games",
            "description": "Games of skill and arcade games"
        }
    }
]
```

---

**Request**

GET `/attractions/1`  -> Gets a specific attraction

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 1,
    "name": "Lights, Camera, Action!: Extreme Stunt Show",
    "max_occupancy": 150,
    "height_requirement_inches": null,
    "area": {
        "id": 5,
        "url": "http://localhost:8000/areas/5",
        "name": "Streets of America",
        "target_population": {
            "id": 3,
            "name": "Adults"
        }
    },
    "category": {
        "id": 3,
        "name": "Themed",
        "description": "Visitors walk through themed structures. Haunted houses, wax museums, etc."
    }
}
```

---

**Request**

GET `/attractions/100`  -> Attempts to get an attraction that doesn't exist

**Response**

HTTP/1.1 404 Not Found

```json
{
    "message": "The requested attraction does not exist, or you do not have permission to access it"
}
```

## Testing

- [ ] Run test suite  -> `python manage.py test tests.AttractionTests -v 1`

```
$ python manage.py test tests.AttractionTests -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..
----------------------------------------------------------------------
Ran 2 tests in 0.197s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Closes #7
- Closes #8