### PR TITLE
Added endpoint to get attractions within a specific park area and tests to validate.

### DIFF
--- a/kennywoodapi/views/attraction.py
+++ b/kennywoodapi/views/attraction.py
@@ -19,7 +19,7 @@ class AttractionSerializer(serializers.HyperlinkedModelSerializer):
             view_name="attraction-detail",
             lookup_field='id'
         )
-        fields = ('id', 'name', 'max_occupancy',
+        fields = ('id', 'url', 'name', 'max_occupancy',
                   'height_requirement_inches', 'area', 'category')
 
 

--- a/tests/attraction.py
+++ b/tests/attraction.py
@@ -59,6 +59,7 @@ class AttractionTests(APITestCase):
             name="Rides",
             description="Test Rides Description"
         )
+        category.save()
 
         # Create attractions
         first_attraction = Attraction.objects.create(
@@ -68,14 +69,16 @@ class AttractionTests(APITestCase):
             max_occupancy=123,
             height_requirement_inches=36
         )
+        first_attraction.save()
 
-        seond_attraction = Attraction.objects.create(
+        second_attraction = Attraction.objects.create(
             name="Second Attraction",
             area=kids_parkarea,
             category=category,
             max_occupancy=222,
             height_requirement_inches=22
         )
+        second_attraction.save()
 
     def test_list_attractions(self):
         """

--- a/tests/parkarea.py
+++ b/tests/parkarea.py
@@ -2,7 +2,7 @@ import json
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from kennywoodapi.models import ParkArea, TargetPopulation
+from kennywoodapi.models import ParkArea, TargetPopulation, Attraction, AttractionCategory
 
 
 class ParkAreaTests(APITestCase):
@@ -54,6 +54,32 @@ class ParkAreaTests(APITestCase):
         )
         kids_parkarea.save()
 
+        # Create attraction category
+        category = AttractionCategory.objects.create(
+            name="Rides",
+            description="Test Rides Description"
+        )
+        category.save()
+
+        # Create attractions
+        first_attraction = Attraction.objects.create(
+            name="First Attraction",
+            area=adult_parkarea,
+            category=category,
+            max_occupancy=123,
+            height_requirement_inches=36
+        )
+        first_attraction.save()
+
+        second_attraction = Attraction.objects.create(
+            name="Second Attraction",
+            area=adult_parkarea,
+            category=category,
+            max_occupancy=222,
+            height_requirement_inches=22
+        )
+        second_attraction.save()
+
     def test_list_park_areas(self):
         """
         Get list of park areas
@@ -81,3 +107,17 @@ class ParkAreaTests(APITestCase):
         self.assertEqual(json_response["id"], 1)
         self.assertEqual(json_response["name"], "Adult Park Area")
         self.assertEqual(json_response["target_population"]["name"], "Adults")
+
+    def test_retrieve_area_attractions(self):
+        """Get a list of attractions based on the area given"""
+        url = "/areas/1/attractions"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 2)
+        self.assertEqual(json_response[0]["id"], 1)
+        self.assertEqual(json_response[0]["name"], "First Attraction")
+        self.assertEqual(json_response[1]["id"], 2)
+        self.assertEqual(json_response[1]["name"], "Second Attraction")


### PR DESCRIPTION
Added endpoint to get attractions within a specific park area and tests to validate.

## Changes

- Added `/areas/:id/attractions` endpoint which lists all attractions within the given area
- Added tests to validate that functionality

## Requests / Responses

**Request**

GET `/area/4/attractions`  -> Gets all attractions for the area with id `4`.

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 5,
        "url": "http://localhost:8000/attractions/5",
        "name": "Living with the Land",
        "max_occupancy": 40,
        "height_requirement_inches": 36,
        "category": {
            "id": 1,
            "name": "Rides",
            "description": "Attractions where visitors sit in a vehicle. Roller coasters, ferris wheels, etc."
        }
    },
    {
        "id": 6,
        "url": "http://localhost:8000/attractions/6",
        "name": "New Attraction",
        "max_occupancy": 20,
        "height_requirement_inches": 24,
        "category": {
            "id": 2,
            "name": "Games",
            "description": "Games of skill and arcade games"
        }
    }
]
```

## Testing

- [ ] Run test suite  -> `python manage.py test tests.ParkAreaTests -v 1`

```
$ python manage.py test tests.ParkAreaTests -v 1
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...
----------------------------------------------------------------------
Ran 3 tests in 0.288s

OK
Destroying test database for alias 'default'...
```



## Related Issues

- Closes #6